### PR TITLE
fix: ignore synthetic test breakage auto reports (#11)

### DIFF
--- a/.github/workflows/report-intake.yml
+++ b/.github/workflows/report-intake.yml
@@ -36,6 +36,15 @@ jobs:
             const exactMarker = `<!-- cbv-report-digest:${exactDigest} -->`;
             const aggregateMarker = `<!-- cbv-aggregate-digest:${aggregateDigest} -->`;
             const isUserReport = report.type === 'user_report';
+            const isSyntheticTestBreakage = !isUserReport && (
+              diagnostics.reason === 'test_breakage' ||
+              String(diagnostics.selectorVersion || '').startsWith('test-')
+            );
+            if (isSyntheticTestBreakage) {
+              core.info('Skip synthetic test breakage report to avoid noisy issues.');
+              return;
+            }
+
             const baseLabels = [
               isUserReport ? 'user-report' : 'auto-report',
             ];


### PR DESCRIPTION
## 背景
Issue #11 来自 `test_breakage` / `test-v2` 的合成探测数据，会导致仓库出现噪声告警。

## 变更
- 在 report intake workflow 中增加早退逻辑
- 对非 `user_report` 且 `reason=test_breakage` 或 `selectorVersion` 以 `test-` 开头的报告，直接跳过 issue upsert

## 影响
- 仅过滤合成测试噪声
- 不影响真实用户上报与正式自动探测

Closes #11
