### PR TITLE
fix: remove labeled trigger to prevent duplicate codex comments

### DIFF
--- a/.github/workflows/codex-trigger.yml
+++ b/.github/workflows/codex-trigger.yml
@@ -2,7 +2,7 @@ name: Trigger Codex Review
 
 on:
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened]
 
 jobs:
   trigger:


### PR DESCRIPTION
Remove 'labeled' from codex-trigger.yml event types. The 'opened' + 'labeled' combination caused two @codex comments per PR when OpenClaw adds the auto-fix label separately from opening the PR.