### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat Branch Visualizer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Visualize conversation branches in ChatGPT/Claude as a native sidebar.",
   "permissions": ["storage", "sidePanel", "tabs"],
   "host_permissions": [

--- a/selectors.json
+++ b/selectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lastVerified": "2026-03-11",
   "platforms": {
     "chatgpt": {


### PR DESCRIPTION
## Summary
- bump extension version from 0.3.2 to 0.3.3
- include privacy redaction release from #28

## Release
- prepare v0.3.3 package and GitHub release