### PR TITLE
fix: update selectors for ChatGPT Custom GPTs and Claude

### DIFF
--- a/selectors.json
+++ b/selectors.json
@@ -7,7 +7,9 @@
         "article[data-testid^='conversation-turn-']",
         "[data-testid='conversation-turn']",
         "[data-message-author-role]",
-        "[data-message-id]"
+        "[data-message-id]",
+        "div[class*=\"agent-turn\"]",
+        "[data-testid*=\"conversation-turn\"]"
       ],
       "turnRoleAttr": "data-turn",
       "messageIdAttr": "data-message-id",
@@ -36,7 +38,8 @@
         "[class*='human-turn']",
         "[class*='HumanTurn']",
         ".font-user-message",
-        "[class*=\"user-message\"]"
+        "[class*=\"user-message\"]",
+        "div[data-is-user=\"true\"]"
       ],
       "assistantTurn": [
         "[data-testid='assistant-turn']",


### PR DESCRIPTION
Fixes #49, Fixes #50. Add fallback selectors to correctly detect turns in Claude and ChatGPT Custom GPT pages.