### PR TITLE
fix: update chatgpt turns selectors for v0.3.7

### DIFF
--- a/selectors.json
+++ b/selectors.json
@@ -7,7 +7,9 @@
         "article[data-testid^='conversation-turn-']",
         "[data-testid='conversation-turn']",
         "[data-message-author-role]",
-        "[data-message-id]"
+        "[data-message-id]",
+        "div[class*=\"agent-turn\"]",
+        "[data-testid*=\"conversation-turn\"]"
       ],
       "turnRoleAttr": "data-turn",
       "messageIdAttr": "data-message-id",
@@ -36,7 +38,8 @@
         "[class*='human-turn']",
         "[class*='HumanTurn']",
         ".font-user-message",
-        "[class*=\"user-message\"]"
+        "[class*=\"user-message\"]",
+        "div[data-is-user=\"true\"]"
       ],
       "assistantTurn": [
         "[data-testid='assistant-turn']",

--- a/selectors.json
+++ b/selectors.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.3.6",
-  "lastVerified": "2026-04-11",
+  "version": "0.3.7",
+  "lastVerified": "2026-05-29",
   "platforms": {
     "chatgpt": {
       "turns": [
@@ -9,7 +9,8 @@
         "[data-message-author-role]",
         "[data-message-id]",
         "div[class*=\"agent-turn\"]",
-        "[data-testid*=\"conversation-turn\"]"
+        "[data-testid*=\"conversation-turn\"]",
+        ".group\\/conversation-turn"
       ],
       "turnRoleAttr": "data-turn",
       "messageIdAttr": "data-message-id",


### PR DESCRIPTION
Automated fix for issue #50. Adds `.group/conversation-turn` to chatgpt turns selectors.