### PR TITLE
release: v0.3.8 parser and reporting fixes

### DIFF
--- a/.github/workflows/report-intake.yml
+++ b/.github/workflows/report-intake.yml
@@ -18,9 +18,36 @@ jobs:
           script: |
             const AUTO_THRESHOLD = 3;
             const BUFFER_LABEL = 'report-buffer';
+            const EXACT_REPEAT_WINDOW_MS = 6 * 60 * 60 * 1000;
             const payload = context.payload.client_payload || {};
             const report = payload.report || {};
             const diagnostics = report.diagnostics || {};
+            function routeKind(platform, input) {
+              let parts = [];
+              try {
+                parts = new URL(String(input || '')).pathname.split('/').filter(Boolean);
+              } catch (_) {
+                parts = String(input || '').split('?')[0].split('#')[0].split('/').filter(Boolean);
+              }
+              if (platform === 'chatgpt') {
+                if (parts[0] === 'c' && parts[1]) return 'chatgpt-conversation';
+                if (parts[0] === 'branch' && parts[1]) return 'chatgpt-branch-conversation';
+                if (parts[0] === 'g') {
+                  const conversationIndex = parts.indexOf('c', 2);
+                  if (parts[1] && conversationIndex >= 2 && parts[conversationIndex + 1]) {
+                    return 'chatgpt-project-conversation';
+                  }
+                }
+              }
+              if (platform === 'claude' && parts[0] === 'chat' && parts[1]) {
+                return 'claude-conversation';
+              }
+              return 'non-conversation';
+            }
+            const route = routeKind(
+              diagnostics.platform || 'unknown',
+              diagnostics.url || report.tabUrl || '',
+            );
             const exactDigest = payload.digest || 'unknown';
             const aggregateDigest = require('crypto')
               .createHash('sha256')
@@ -30,6 +57,7 @@ jobs:
                 reason: diagnostics.reason || 'unknown',
                 broken: diagnostics.probe?.broken || [],
                 selectorVersion: diagnostics.selectorVersion || 'unknown',
+                route,
               }))
               .digest('hex')
               .slice(0, 16);
@@ -42,6 +70,10 @@ jobs:
             );
             if (isSyntheticTestBreakage) {
               core.info('Skip synthetic test breakage report to avoid noisy issues.');
+              return;
+            }
+            if (!isUserReport && diagnostics.reason === 'no_turns_detected' && route === 'non-conversation') {
+              core.info('Skip no_turns_detected report outside a supported conversation route.');
               return;
             }
 
@@ -82,6 +114,7 @@ jobs:
               `- Reason: \`${diagnostics.reason || 'unknown'}\``,
               `- Selector version: \`${diagnostics.selectorVersion || 'unknown'}\``,
               `- URL: ${diagnostics.url || report.tabUrl || 'unknown'}`,
+              `- Route: \`${route}\``,
               `- Broken probes: \`${(diagnostics.probe?.broken || []).join(', ') || 'none'}\``,
               ];
               if (count != null) {
@@ -113,6 +146,22 @@ jobs:
             const bufferIssue = matchingIssues.find(issue => (issue.labels || []).some(label => (label.name || label) === BUFFER_LABEL));
 
             if (visibleIssue) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: visibleIssue.number,
+                per_page: 100,
+              });
+              const repeatedRecently = comments.some(comment => {
+                const createdAt = Date.parse(comment.created_at || '');
+                return (comment.body || '').includes(`Exact digest: \`${exactDigest}\``)
+                  && Number.isFinite(createdAt)
+                  && Date.now() - createdAt < EXACT_REPEAT_WINDOW_MS;
+              });
+              if (repeatedRecently) {
+                core.info(`Skip repeated exact digest ${exactDigest} within the comment window.`);
+                return;
+              }
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Visualize your ChatGPT and Claude conversation branches as an interactive tree — in Chrome's native side panel.**
 
-[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.7-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
+[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.8-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>
@@ -52,6 +52,7 @@ git clone https://github.com/FuugaMo/chat-branch-visualizer.git
 ├── manifest.json          Extension manifest (MV3)
 ├── content.js             DOM parser + branch navigator (runs in chat pages)
 ├── platform-config.js     Platform detection shared across contexts
+├── conversation-routes.js Supported conversation route classification
 ├── reporting-config.js    Diagnostics reporting config
 ├── selectors.json         CSS selector registry for both platforms
 ├── background.js          Service worker — message routing + auto-reporting
@@ -82,10 +83,10 @@ When breakage is detected and the user has opted in, a report flows through:
 content.js detects selector breakage / build error
   └─ PROBE_RESULT → background.js
        ├─ Consent check (cbv_consent.autoSend must be true)
-       ├─ Deduplication (same platform+reason+broken selectors+url within 30 min → skip)
+       ├─ Deduplication (same platform+reason+broken selectors+route within 30 min → skip)
        └─ POST ──▶ api/reports.js (Vercel)
                         └─ repository_dispatch: extension_breakage_report
-                             └─ report-intake.yml
+                             └─ report-intake.yml (route-aware aggregation + repeat suppression)
                                   └─ Buffer: 3 identical reports → promoted to visible issue
                                        └─ OpenClaw opens fix PR (auto-fix label)
                                             └─ Codex reviews → human approves → auto-merge

--- a/api/reports.js
+++ b/api/reports.js
@@ -7,6 +7,7 @@ const {
   githubRequest,
   parseReportBody,
 } = require('./_lib/reporting');
+const { isConversationRoute } = require('../conversation-routes');
 
 function readBody(req) {
   if (req.body) return Promise.resolve(req.body);
@@ -51,6 +52,14 @@ module.exports = async (req, res) => {
     }
     if (!isAuthorized(req, report)) {
       return res.status(401).json({ ok: false, error: 'unauthorized' });
+    }
+    if (report.type !== 'user_report'
+        && report.diagnostics.reason === 'no_turns_detected'
+        && !isConversationRoute(report.diagnostics.platform, report.diagnostics.url || report.tabUrl)) {
+      return res.status(202).json({
+        ok: true,
+        skipped: 'non_conversation_route',
+      });
     }
 
     const token = process.env.GITHUB_TOKEN;

--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
 //   1. Open side panel when toolbar icon clicked
 //   2. Route messages between content.js <-> sidepanel.js
 
-importScripts('platform-config.js', 'reporting-config.js');
+importScripts('platform-config.js', 'conversation-routes.js', 'reporting-config.js');
 
 // ── Open side panel on action click ──────────────────────────────────────────
 chrome.action.onClicked.addListener(tab => {
@@ -48,7 +48,15 @@ function sanitizeUrlForDiagnostics(input) {
 
     // Keep only route pattern, remove concrete identifiers/query/hash.
     if (first === 'c') return `${parsed.origin}/c/:id`;
-    if (first === 'g') return `${parsed.origin}/g/:id`;
+    if (first === 'branch') return `${parsed.origin}/branch/:id`;
+    if (first === 'g') {
+      const conversationIndex = parts.indexOf('c', 2);
+      if (conversationIndex >= 2 && parts[conversationIndex + 1]) {
+        return `${parsed.origin}/g/:id/c/:id`;
+      }
+      return `${parsed.origin}/g/:id`;
+    }
+    if (first === 'chat') return `${parsed.origin}/chat/:id`;
     if (!first) return `${parsed.origin}/`;
     if (second) return `${parsed.origin}/${first}/${second}`;
     return `${parsed.origin}/${first}`;
@@ -60,9 +68,10 @@ function sanitizeUrlForDiagnostics(input) {
 function sanitizePageLabel(inputUrl, platform = '') {
   const base = sanitizeText(platform || 'unknown', 24) || 'unknown';
   try {
+    const route = cbvClassifyConversationRoute(platform, inputUrl);
+    if (route !== 'non-conversation') return `${base}:${route}`;
     const path = new URL(String(inputUrl || '')).pathname || '/';
-    if (path.includes('/c/')) return `${base}:conversation`;
-    if (path.startsWith('/g/')) return `${base}:project`; 
+    if (path.startsWith('/g/')) return `${base}:project`;
     if (path.startsWith('/apps')) return `${base}:apps`;
     return `${base}:page`;
   } catch (_) {
@@ -79,19 +88,12 @@ function pruneReportedDiagnostics(now = Date.now()) {
 
 function buildReportKey(diagnostics) {
   const broken = (diagnostics?.probe?.broken || []).join(',');
-  const url = (() => {
-    try {
-      const parsed = new URL(diagnostics?.url || '');
-      return `${parsed.origin}${parsed.pathname}`;
-    } catch (_) {
-      return sanitizeText(diagnostics?.url || '', 180);
-    }
-  })();
+  const route = cbvClassifyConversationRoute(diagnostics?.platform, diagnostics?.url);
   return [
     sanitizeText(diagnostics?.platform, 24),
     sanitizeText(diagnostics?.reason, 64),
     broken,
-    url,
+    route,
     Number.isFinite(diagnostics?.turnCount) ? diagnostics.turnCount : 0,
   ].join('|');
 }
@@ -167,6 +169,9 @@ async function shouldAutoSendDiagnostics(diagnostics) {
   if (platform !== 'chatgpt' && platform !== 'claude') return false;
   const reason = diagnostics?.reason || '';
   const broken = diagnostics?.probe?.broken || [];
+  if (reason === 'no_turns_detected' && !cbvIsConversationRoute(platform, diagnostics?.url)) {
+    return false;
+  }
   return broken.length > 0 || reason === 'build_error' || reason === 'no_turns_detected' || reason === 'branch_navigation_warning';
 }
 
@@ -176,6 +181,10 @@ async function postReport({ type, diagnostics, description = '', sender }) {
 
   const sanitized = sanitizeDiagnostics(diagnostics);
   if (!sanitized) return { ok: false, skipped: 'missing_diagnostics' };
+  if (type === 'auto_probe' && sanitized.reason === 'no_turns_detected'
+      && !cbvIsConversationRoute(sanitized.platform, sanitized.url)) {
+    return { ok: true, skipped: 'non_conversation_route' };
+  }
 
   const key = buildReportKey(sanitized);
   if (type === 'auto_probe' && wasDiagnosticRecentlySent(key)) {
@@ -200,8 +209,8 @@ async function postReport({ type, diagnostics, description = '', sender }) {
         client: 'chrome-extension',
         publicKey: config.publicKey || '',
         description: sanitizeText(description, 1500),
-        tabUrl: sanitizeUrlForDiagnostics(sender?.tab?.url || sanitized.url),
-        pageTitle: sanitizePageLabel(sender?.tab?.url || sanitized.url, sanitized.platform),
+        tabUrl: sanitized.url,
+        pageTitle: sanitizePageLabel(sanitized.url, sanitized.platform),
         extensionVersion: sanitizeText(sanitized.extensionVersion, 24),
         selectorVersion: sanitizeText(sanitized.selectorVersion, 40),
         diagnostics: sanitized,

--- a/content.js
+++ b/content.js
@@ -817,21 +817,21 @@ function makePathEntry(turn) {
   // Locates the X/Y branch counter and associated prev/next buttons.
   // Works for both ChatGPT (aria-label Chinese/English) and Claude.
   function findChatGPTBranchNav(container) {
-    return findBranchNavInside(container, { allowPositionalFallback: false });
+    return findBranchNavInside(container, { positionalFallback: 'sided' });
   }
 
   function findClaudeBranchNav(container) {
-    return findBranchNavInside(container, { allowPositionalFallback: true }) || findNearbyClaudeBranchNav(container);
+    return findBranchNavInside(container, { positionalFallback: 'nearest' }) || findNearbyClaudeBranchNav(container);
   }
 
-  function findBranchNavInside(root, { allowPositionalFallback = true } = {}) {
-    return resolveBranchNavFromCandidates(getBranchCounterCandidates(root), { allowPositionalFallback });
+  function findBranchNavInside(root, { positionalFallback = 'nearest' } = {}) {
+    return resolveBranchNavFromCandidates(getBranchCounterCandidates(root), { positionalFallback });
   }
 
   function findNearbyClaudeBranchNav(container) {
     const containerRect = container.getBoundingClientRect();
     const nearby = getBranchCounterCandidates(document)
-      .map(candidate => ({ candidate, nav: resolveBranchNavCandidate(candidate, { allowPositionalFallback: true }) }))
+      .map(candidate => ({ candidate, nav: resolveBranchNavCandidate(candidate, { positionalFallback: 'nearest' }) }))
       .filter(entry => entry.nav)
       .map(entry => {
         const rect = entry.candidate.el.getBoundingClientRect();
@@ -886,7 +886,7 @@ function makePathEntry(turn) {
     return null;
   }
 
-  function resolveBranchNavCandidate({ el, current, total }, { allowPositionalFallback = true } = {}) {
+  function resolveBranchNavCandidate({ el, current, total }, { positionalFallback = 'nearest' } = {}) {
     let node = el.parentElement;
     for (let lvl = 0; lvl < 6 && node; lvl++) {
       const btns = [...node.querySelectorAll('button')].filter(isVisibleButton);
@@ -905,29 +905,35 @@ function makePathEntry(turn) {
       });
       if (prevBtn && nextBtn) return { current, total, prevBtn, nextBtn };
 
-      if (allowPositionalFallback && btns.length >= 2) {
+      if (positionalFallback === 'sided' && btns.length >= 2) {
+        const counterRect = el.getBoundingClientRect();
+        const positional = cbvFindPositionalBranchButtons(
+          counterRect,
+          btns.map(button => ({ button, rect: button.getBoundingClientRect() }))
+        );
+        if (positional) return { current, total, ...positional };
+      }
+
+      if (positionalFallback === 'nearest' && btns.length >= 2) {
         const counterRect = el.getBoundingClientRect();
         const withDist = btns
-          .map(b => {
-            const r = b.getBoundingClientRect();
-            const centerX = (r.left + r.right) / 2;
-            const centerY = (r.top + r.bottom) / 2;
+          .map(button => {
+            const rect = button.getBoundingClientRect();
+            const centerX = (rect.left + rect.right) / 2;
+            const centerY = (rect.top + rect.bottom) / 2;
             const counterCenterX = (counterRect.left + counterRect.right) / 2;
             const counterCenterY = (counterRect.top + counterRect.bottom) / 2;
             return {
-              b,
+              button,
               dist: Math.abs(centerX - counterCenterX) + Math.abs(centerY - counterCenterY),
-              left: r.left,
+              left: rect.left,
             };
           })
           .sort((a, b) => a.dist - b.dist);
-
-        if (withDist.length >= 2) {
-          const [a, b] = withDist;
-          const leftBtn = a.left < b.left ? a.b : b.b;
-          const rightBtn = a.left < b.left ? b.b : a.b;
-          return { current, total, prevBtn: leftBtn, nextBtn: rightBtn };
-        }
+        const [first, second] = withDist;
+        const prevBtn = first.left < second.left ? first.button : second.button;
+        const nextBtn = first.left < second.left ? second.button : first.button;
+        return { current, total, prevBtn, nextBtn };
       }
 
       node = node.parentElement;

--- a/content.js
+++ b/content.js
@@ -11,6 +11,7 @@
   const DEBOUNCE_MS   = 180;
   const VIEWPORT_SYNC_MS = 100;
   const BUILD_TIMEOUT_MS = 45000;
+  const EMPTY_TURN_CONFIRMATIONS = 3;
   const DIAGNOSTIC_SNIPPET_LIMIT = 6;
   const PLATFORM      = detectPlatform();
   const EXT_VERSION   = chrome.runtime.getManifest().version;
@@ -28,8 +29,10 @@
           "[data-testid='conversation-turn']",
           '[data-message-author-role]',
           '[data-message-id]',
+          '.conversation-turn',
+          '[data-role]',
         ],
-        turnRoleAttr: { type: 'attr', names: ['data-message-author-role', 'data-turn'] },
+        turnRoleAttr: { type: 'attr', names: ['data-message-author-role', 'data-turn', 'data-role'] },
         messageIdAttr: { type: 'attr', name: 'data-message-id' },
         branchCounter: { type: 'regex', pattern: '^\\d+\\s*/\\s*\\d+$' },
         branchPrev: ["[aria-label*='prev' i]", "[aria-label*='previous' i]", "[aria-label*='earlier' i]"],
@@ -47,6 +50,7 @@
           "[class*='human-turn']",
           "[class*='HumanTurn']",
           "[class*='UserMessage']",
+          '[data-is-user="true"]',
           '.font-user-message',
           '[class*="user-message"]',
         ],
@@ -57,6 +61,8 @@
           '.font-claude-response-body',
           '.standard-markdown',
           "[class*='font-claude-message']",
+          '[data-message-author-role="assistant"]',
+          '[data-is-user="false"]',
         ],
         branchCounter: { type: 'regex', pattern: '^\\d+\\s*/\\s*\\d+$' },
         branchPrev: ["[aria-label*='prev' i]", "[aria-label*='previous' i]", "[aria-label*='上一']"],
@@ -81,6 +87,7 @@
   let lastDiagnostics = null;
   let lastDiagnosticSig = '';
   let pageLoadStartedAt = Date.now();
+  let emptyTurnPolls = 0;
 
   // ── Platform ────────────────────────────────────────────────────────────────
   function detectPlatform() {
@@ -593,8 +600,12 @@ function makePathEntry(turn) {
   }
 
   function getChatGPTMessageTurns() {
+    const configured = selectorConfig?.platforms?.chatgpt?.turns || [];
     return dedupeElements(selectTopLevelCandidates([
+      ...configured,
       '[data-message-author-role]',
+      '[data-role]',
+      '.conversation-turn',
       "[data-testid='conversation-turn']",
       '[data-testid*="conversation-turn"]',
       '[data-testid*="message"]',
@@ -605,10 +616,14 @@ function makePathEntry(turn) {
   }
 
   function mapChatGPTTurn(turn, idx) {
-    const roleSource = turn.matches?.('[data-message-author-role]')
+    const roleSource = turn.matches?.('[data-message-author-role], [data-role]')
       ? turn
-      : turn.querySelector?.('[data-message-author-role]');
-    const roleValue = roleSource?.getAttribute('data-message-author-role') || turn.getAttribute('data-turn') || '';
+      : turn.querySelector?.('[data-message-author-role], [data-role]');
+    const configuredRoleAttrs = selectorConfig?.platforms?.chatgpt?.turnRoleAttr?.names || [];
+    const roleAttrs = [...new Set(['data-message-author-role', 'data-turn', 'data-role', ...configuredRoleAttrs])];
+    const roleValue = roleAttrs
+      .map(attr => roleSource?.getAttribute(attr) || turn.getAttribute(attr))
+      .find(Boolean) || '';
     const role = roleValue === 'user' ? 'user' : 'assistant';
     const msgDiv = turn.querySelector?.('[data-message-id]') || null;
     const msgId = msgDiv?.getAttribute('data-message-id')
@@ -679,6 +694,7 @@ function makePathEntry(turn) {
 
   function getClaudeUserTurns() {
     const selectors = [
+      ...(selectorConfig?.platforms?.claude?.humanTurn || []),
       '[data-testid="user-message"]',
       '[data-testid*="user-message"]',
       '[class*="font-user-message"]',
@@ -688,6 +704,7 @@ function makePathEntry(turn) {
       '[class*="human-turn"]',
       '[class*="HumanTurn"]',
       '[class*="UserMessage"]',
+      '[data-is-user="true"]',
     ];
     return dedupeElements(selectTopLevelCandidates(selectors)
       .filter(el => isReadableTurnCandidate(el, { minText: 0 })))
@@ -765,12 +782,15 @@ function makePathEntry(turn) {
 
   function getClaudeAssistantCandidates(userEls) {
     const selectors = [
+      ...(selectorConfig?.platforms?.claude?.assistantTurn || []),
       '[data-testid="assistant-turn"]',
       '[data-testid="assistant-message"]',
       '.font-claude-response',
       '.font-claude-response-body',
       '.standard-markdown',
       '[class*="font-claude-message"]',
+      '[data-message-author-role="assistant"]',
+      '[data-is-user="false"]',
       'main [class*="prose"]',
       'main [class*="whitespace-pre-wrap"]',
       'main [class*="markdown"]',
@@ -781,7 +801,7 @@ function makePathEntry(turn) {
       'main blockquote',
     ];
 
-    return dedupeElements(selectors.flatMap(sel => [...document.querySelectorAll(sel)]))
+    return dedupeElements(selectors.flatMap(safeQueryAll))
       .filter(el => isReadableTurnCandidate(el, { minText: 8 }))
       .filter(el => !userEls.some(userEl => userEl === el || userEl.contains(el)))
       .filter(el => !isClaudeBranchNavWidget(el))
@@ -951,8 +971,16 @@ function makePathEntry(turn) {
   }
 
   function selectTopLevelCandidates(selectors) {
-    const all = dedupeElements(selectors.flatMap(sel => [...document.querySelectorAll(sel)]));
+    const all = dedupeElements(selectors.flatMap(safeQueryAll));
     return all.filter(el => !all.some(other => other !== el && other.contains(el)));
+  }
+
+  function safeQueryAll(selector) {
+    try {
+      return [...document.querySelectorAll(selector)];
+    } catch (_) {
+      return [];
+    }
   }
 
   function dedupeElements(elements) {
@@ -1093,42 +1121,27 @@ function makePathEntry(turn) {
     return false;
   }
 
-  function isLikelyChatConversationPage() {
-    const path = (() => {
-      try {
-        return new URL(location.href).pathname || '';
-      } catch (_) {
-        return location.pathname || '';
-      }
-    })();
-
-    if (PLATFORM === 'chatgpt') {
-      return path.includes('/c/');
-    }
-
-    if (PLATFORM === 'claude') {
-      return path.startsWith('/chat/');
-    }
-
-    return false;
-  }
-
   function syncStateToPanel(force = false) {
     const turns = serializeTurns(readRawTurns());
     if (!turns.length) {
+      emptyTurnPolls += 1;
       if (pageSeemsLoading()) {
         sendToPanel({ type: 'CONVERSATION_LOADING' });
         return;
       }
-      if (isLikelyChatConversationPage()) {
+      if (document.visibilityState === 'visible'
+          && emptyTurnPolls >= EMPTY_TURN_CONFIRMATIONS
+          && cbvIsConversationRoute(PLATFORM, location.href)) {
         maybeReportBreakage('no_turns_detected', {
           phase: 'sync',
           force,
+          route: cbvClassifyConversationRoute(PLATFORM, location.href),
         });
       }
       sendToPanel({ type: 'CONVERSATION_LOADING' });
       return;
     }
+    emptyTurnPolls = 0;
     const activePath = turns.map(makePathEntry);
     const sig = JSON.stringify(turns.map(t => `${t.id}:${t.branchTotal}:${textSignature(t.text)}`));
     if (!force && sig === lastStateSig) return;
@@ -1146,6 +1159,7 @@ function makePathEntry(turn) {
         lastVisibleSig = '';
         lastDiagnostics = null;
         lastDiagnosticSig = '';
+        emptyTurnPolls = 0;
         resetLoadingWindow();
         sendToPanel({ type: 'PAGE_READY', platform: PLATFORM, url: location.href });
         syncStateToPanel(true);

--- a/conversation-routes.js
+++ b/conversation-routes.js
@@ -1,0 +1,46 @@
+(function initCbvConversationRoutes(global) {
+  'use strict';
+
+  function pathSegments(input) {
+    try {
+      return new URL(String(input || '')).pathname.split('/').filter(Boolean);
+    } catch (_) {
+      return String(input || '').split('?')[0].split('#')[0].split('/').filter(Boolean);
+    }
+  }
+
+  function classifyConversationRoute(platform, input) {
+    const segments = pathSegments(input);
+
+    if (platform === 'chatgpt') {
+      if (segments[0] === 'c' && segments[1]) return 'chatgpt-conversation';
+      if (segments[0] === 'branch' && segments[1]) return 'chatgpt-branch-conversation';
+      if (segments[0] === 'g') {
+        const conversationIndex = segments.indexOf('c', 2);
+        if (segments[1] && conversationIndex >= 2 && segments[conversationIndex + 1]) {
+          return 'chatgpt-project-conversation';
+        }
+      }
+    }
+
+    if (platform === 'claude' && segments[0] === 'chat' && segments[1]) {
+      return 'claude-conversation';
+    }
+
+    return 'non-conversation';
+  }
+
+  function isConversationRoute(platform, input) {
+    return classifyConversationRoute(platform, input) !== 'non-conversation';
+  }
+
+  global.cbvClassifyConversationRoute = classifyConversationRoute;
+  global.cbvIsConversationRoute = isConversationRoute;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      classifyConversationRoute,
+      isConversationRoute,
+    };
+  }
+})(globalThis);

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
         "https://chat.openai.com/*",
         "https://claude.ai/*"
       ],
-      "js": ["platform-config.js", "reporting-config.js", "content.js"],
+      "js": ["platform-config.js", "nav-geometry.js", "reporting-config.js", "content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat Branch Visualizer",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Visualize conversation branches in ChatGPT/Claude as a native sidebar.",
   "permissions": ["storage", "sidePanel", "tabs"],
   "host_permissions": [
@@ -32,7 +32,7 @@
         "https://chat.openai.com/*",
         "https://claude.ai/*"
       ],
-      "js": ["platform-config.js", "nav-geometry.js", "reporting-config.js", "content.js"],
+      "js": ["platform-config.js", "conversation-routes.js", "nav-geometry.js", "reporting-config.js", "content.js"],
       "run_at": "document_idle"
     }
   ],

--- a/nav-geometry.js
+++ b/nav-geometry.js
@@ -1,0 +1,63 @@
+(function initCbvNavGeometry(global) {
+  'use strict';
+
+  function centerX(rect) {
+    return (rect.left + rect.right) / 2;
+  }
+
+  function centerY(rect) {
+    return (rect.top + rect.bottom) / 2;
+  }
+
+  function horizontalGap(buttonRect, counterRect, side) {
+    return side === 'left'
+      ? counterRect.left - buttonRect.right
+      : buttonRect.left - counterRect.right;
+  }
+
+  function findPositionalBranchButtons(counterRect, buttons, options = {}) {
+    const maxHorizontalGap = options.maxHorizontalGap ?? 96;
+    const maxVerticalOffset = options.maxVerticalOffset
+      ?? Math.max(16, (counterRect.bottom - counterRect.top) * 0.75);
+    const counterCenterX = centerX(counterRect);
+    const counterCenterY = centerY(counterRect);
+
+    function nearestOnSide(side) {
+      return buttons
+        .map(entry => {
+          const buttonCenterX = centerX(entry.rect);
+          const verticalOffset = Math.abs(centerY(entry.rect) - counterCenterY);
+          const gap = horizontalGap(entry.rect, counterRect, side);
+          return { ...entry, buttonCenterX, verticalOffset, gap };
+        })
+        .filter(entry => {
+          const isOnSide = side === 'left'
+            ? entry.buttonCenterX < counterCenterX
+            : entry.buttonCenterX > counterCenterX;
+          return isOnSide
+            && entry.verticalOffset <= maxVerticalOffset
+            && entry.gap >= -4
+            && entry.gap <= maxHorizontalGap;
+        })
+        .sort((a, b) => {
+          if (a.gap !== b.gap) return a.gap - b.gap;
+          return a.verticalOffset - b.verticalOffset;
+        })[0] || null;
+    }
+
+    const left = nearestOnSide('left');
+    const right = nearestOnSide('right');
+    if (!left || !right || left.button === right.button) return null;
+
+    return {
+      prevBtn: left.button,
+      nextBtn: right.button,
+    };
+  }
+
+  global.cbvFindPositionalBranchButtons = findPositionalBranchButtons;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { findPositionalBranchButtons };
+  }
+})(globalThis);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chat-branch-visualizer-dev",
   "private": true,
   "scripts": {
+    "test": "node --test",
     "probe": "node scripts/probe.js",
     "review": "node scripts/review-pr.js",
     "patch": "node scripts/openclaw-patch.js",

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -20,6 +20,7 @@ const INCLUDE = [
   'background.js',
   'content.js',
   'platform-config.js',
+  'nav-geometry.js',
   'reporting-config.js',
   'selectors.json',
   'sidepanel.html',

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -20,6 +20,7 @@ const INCLUDE = [
   'background.js',
   'content.js',
   'platform-config.js',
+  'conversation-routes.js',
   'nav-geometry.js',
   'reporting-config.js',
   'selectors.json',

--- a/selectors.json
+++ b/selectors.json
@@ -1,17 +1,19 @@
 {
-  "version": "0.3.7",
-  "lastVerified": "2026-06-22",
+  "version": "0.3.8",
+  "lastVerified": "2026-08-11",
   "platforms": {
     "chatgpt": {
       "turns": [
         "article[data-testid^='conversation-turn-']",
         "[data-testid='conversation-turn']",
         "[data-message-author-role]",
-        "[data-message-id]"
+        "[data-message-id]",
+        ".conversation-turn",
+        "[data-role]"
       ],
       "turnRoleAttr": {
         "type": "attr",
-        "names": ["data-message-author-role", "data-turn"]
+        "names": ["data-message-author-role", "data-turn", "data-role"]
       },
       "messageIdAttr": {
         "type": "attr",
@@ -46,7 +48,8 @@
         "[class*='HumanTurn']",
         "[class*='UserMessage']",
         ".font-user-message",
-        "[class*=\"user-message\"]"
+        "[class*=\"user-message\"]",
+        "[data-is-user='true']"
       ],
       "assistantTurn": [
         "[data-testid='assistant-turn']",
@@ -54,7 +57,9 @@
         ".font-claude-response",
         ".font-claude-response-body",
         ".standard-markdown",
-        "[class*='font-claude-message']"
+        "[class*='font-claude-message']",
+        "[data-message-author-role='assistant']",
+        "[data-is-user='false']"
       ],
       "branchCounter": {
         "type": "regex",

--- a/test/conversation-routes.test.js
+++ b/test/conversation-routes.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  classifyConversationRoute,
+  isConversationRoute,
+} = require('../conversation-routes');
+
+const supportedRoutes = [
+  ['chatgpt', 'https://chatgpt.com/c/abc', 'chatgpt-conversation'],
+  ['chatgpt', 'https://chatgpt.com/g/g-p-project/c/abc', 'chatgpt-project-conversation'],
+  ['chatgpt', 'https://chatgpt.com/g/g-custom/c/abc', 'chatgpt-project-conversation'],
+  ['chatgpt', 'https://chatgpt.com/branch/abc/def', 'chatgpt-branch-conversation'],
+  ['chatgpt', 'https://chat.openai.com/c/abc', 'chatgpt-conversation'],
+  ['claude', 'https://claude.ai/chat/abc', 'claude-conversation'],
+];
+
+for (const [platform, url, expected] of supportedRoutes) {
+  test(`recognizes ${expected}`, () => {
+    assert.equal(classifyConversationRoute(platform, url), expected);
+    assert.equal(isConversationRoute(platform, url), true);
+  });
+}
+
+const unsupportedRoutes = [
+  ['chatgpt', 'https://chatgpt.com/'],
+  ['chatgpt', 'https://chatgpt.com/?utm_source=search'],
+  ['chatgpt', 'https://chatgpt.com/g/g-p-project/project'],
+  ['chatgpt', 'https://chatgpt.com/g/g-custom'],
+  ['claude', 'https://claude.ai/recents'],
+  ['claude', 'https://claude.ai/code/artifact/abc'],
+  ['claude', 'https://claude.ai/apps'],
+];
+
+for (const [platform, url] of unsupportedRoutes) {
+  test(`rejects non-conversation route ${url}`, () => {
+    assert.equal(classifyConversationRoute(platform, url), 'non-conversation');
+    assert.equal(isConversationRoute(platform, url), false);
+  });
+}

--- a/test/nav-geometry.test.js
+++ b/test/nav-geometry.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { findPositionalBranchButtons } = require('../nav-geometry');
+
+function rect(left, top, width = 24, height = 24) {
+  return {
+    left,
+    right: left + width,
+    top,
+    bottom: top + height,
+  };
+}
+
+function candidate(name, bounds) {
+  return {
+    button: { name },
+    rect: bounds,
+  };
+}
+
+test('finds unlabeled branch buttons on either side of the counter', () => {
+  const result = findPositionalBranchButtons(
+    rect(100, 40, 32, 20),
+    [
+      candidate('copy', rect(20, 40)),
+      candidate('previous', rect(68, 38)),
+      candidate('next', rect(140, 38)),
+      candidate('edit', rect(188, 40)),
+    ]
+  );
+
+  assert.equal(result.prevBtn.name, 'previous');
+  assert.equal(result.nextBtn.name, 'next');
+});
+
+test('rejects buttons that are only on one side of the counter', () => {
+  const result = findPositionalBranchButtons(
+    rect(100, 40, 32, 20),
+    [
+      candidate('copy', rect(36, 40)),
+      candidate('edit', rect(68, 40)),
+    ]
+  );
+
+  assert.equal(result, null);
+});
+
+test('rejects vertically misaligned action buttons', () => {
+  const result = findPositionalBranchButtons(
+    rect(100, 40, 32, 20),
+    [
+      candidate('left action', rect(68, 80)),
+      candidate('right action', rect(140, 80)),
+    ]
+  );
+
+  assert.equal(result, null);
+});
+
+test('rejects buttons too far away from the counter', () => {
+  const result = findPositionalBranchButtons(
+    rect(200, 40, 32, 20),
+    [
+      candidate('left action', rect(20, 40)),
+      candidate('right action', rect(340, 40)),
+    ]
+  );
+
+  assert.equal(result, null);
+});

--- a/test/version-consistency.test.js
+++ b/test/version-consistency.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const manifest = require('../manifest.json');
+const selectors = require('../selectors.json');
+
+test('manifest, selector registry, and README badge use the same version', () => {
+  const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+
+  assert.equal(selectors.version, manifest.version);
+  assert.match(readme, new RegExp(`Chrome%20Web%20Store-v${manifest.version.replaceAll('.', '\\.')}-blue`));
+});


### PR DESCRIPTION
## Summary
- restore ChatGPT branch navigation when controls omit recognizable `aria-label` values
- use the selector registry in the actual ChatGPT and Claude runtime parsers
- recognize direct ChatGPT conversations, Project/Custom-GPT-prefixed conversations, `/branch/...` conversations, and Claude `/chat/...` conversations
- filter `no_turns_detected` only on confirmed non-conversation pages such as ChatGPT home/project listings and Claude recents/artifacts
- enforce route filtering in the content script, service worker, reports API, and GitHub intake workflow
- aggregate reports by route type and suppress identical digest comments for six hours
- hydrate long virtualized conversations by scanning from stable top to bottom boundaries before branch traversal
- merge overlapping virtualized DOM batches with stable turn identities and re-locate off-screen branch controls during DFS
- blur and block the chat while automatic scrolling runs, then restore original branch selections and viewport
- mark a build Partial whenever history boundaries or branch traversal cannot be verified
- bump the extension and selector registry to `0.3.8`

## Automated verification
- `npm test` — 21 passing
- `node --check content.js`
- `node --check sidepanel.js`
- `node --check conversation-routes.js`
- `node --check turn-catalog.js`
- `node --check api/reports.js`
- `npm run check:reporting`
- GitHub workflow YAML parse
- `npm run pack`
- `unzip -t dist/chat-branch-visualizer-0.3.8.zip`

## Manual release validation
- [ ] Build from the middle of a long ChatGPT conversation without pre-scrolling
- [ ] Build a long Project/Custom-GPT-prefixed conversation
- [ ] Build from the middle of a long Claude conversation
- [ ] Verify original branch selections and viewport are restored after success and cancel
- [ ] Verify unverifiable scans display Partial rather than Full

Fixes #62.
Addresses #56 and #57 pending release validation.