### PR TITLE
fix: build complete ChatGPT and Claude trees from conversation graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Visualize your ChatGPT and Claude conversation branches as an interactive tree — in Chrome's native side panel.**
 
-[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.9-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
+[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.10-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Visualize your ChatGPT and Claude conversation branches as an interactive tree — in Chrome's native side panel.**
 
-[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.10-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
+[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.11-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Visualize your ChatGPT and Claude conversation branches as an interactive tree — in Chrome's native side panel.**
 
-[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.8-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
+[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-v0.3.9-blue?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/chat-branch-visualizer/mahknjdihdpeceompocgcclnmjikmncb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
 </div>

--- a/chatgpt-graph.js
+++ b/chatgpt-graph.js
@@ -1,0 +1,122 @@
+(function initCbvChatGptGraph(global) {
+  'use strict';
+
+  function messageText(message) {
+    const parts = message?.content?.parts;
+    if (!Array.isArray(parts)) return '';
+    return parts
+      .map(part => {
+        if (typeof part === 'string') return part;
+        if (typeof part?.text === 'string') return part.text;
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n')
+      .trim()
+      .replace(/\s+/g, ' ');
+  }
+
+  function isVisibleMessage(message) {
+    if (!message || message.metadata?.is_visually_hidden_from_conversation) return false;
+    const role = message.author?.role;
+    const contentType = message.content?.content_type;
+    if (role === 'user') return contentType === 'text' || contentType === 'multimodal_text';
+    if (role !== 'assistant' || !['text', 'multimodal_text'].includes(contentType)) return false;
+    if (message.status && message.status !== 'finished_successfully') return false;
+    return message.end_turn === true || message.channel === 'final';
+  }
+
+  function convertConversationGraph(data) {
+    const mapping = data?.mapping || {};
+    const rawNodes = Object.values(mapping);
+    const visibleNodes = new Map();
+    const visibleChildren = new Map();
+    const roots = rawNodes.filter(node => !node.parent || !mapping[node.parent]);
+
+    function addChild(parentId, childId) {
+      const key = parentId || '__root__';
+      if (!visibleChildren.has(key)) visibleChildren.set(key, []);
+      const children = visibleChildren.get(key);
+      if (!children.includes(childId)) children.push(childId);
+    }
+
+    function visit(rawNode, visibleParentId = null, depth = 0, seen = new Set()) {
+      if (!rawNode || seen.has(rawNode.id)) return;
+      seen.add(rawNode.id);
+
+      let nextParentId = visibleParentId;
+      let nextDepth = depth;
+      if (isVisibleMessage(rawNode.message)) {
+        const id = rawNode.message.id || rawNode.id;
+        visibleNodes.set(id, {
+          id,
+          parentId: visibleParentId,
+          turnIndex: depth,
+          branchIndex: 1,
+          branchTotal: 1,
+          role: rawNode.message.author.role,
+          text: messageText(rawNode.message).slice(0, 220),
+          children: [],
+        });
+        addChild(visibleParentId, id);
+        nextParentId = id;
+        nextDepth = depth + 1;
+      }
+
+      for (const childId of rawNode.children || []) {
+        visit(mapping[childId], nextParentId, nextDepth, seen);
+      }
+    }
+
+    for (const root of roots) visit(root);
+
+    for (const [parentKey, children] of visibleChildren.entries()) {
+      const branchTotal = children.length;
+      children.forEach((childId, index) => {
+        const child = visibleNodes.get(childId);
+        if (!child) return;
+        child.branchIndex = index + 1;
+        child.branchTotal = Math.max(1, branchTotal);
+      });
+      if (parentKey !== '__root__') {
+        const parent = visibleNodes.get(parentKey);
+        if (parent) parent.children = [...children];
+      }
+    }
+
+    const currentRawPath = [];
+    let cursor = data?.current_node;
+    const pathSeen = new Set();
+    while (cursor && mapping[cursor] && !pathSeen.has(cursor)) {
+      pathSeen.add(cursor);
+      currentRawPath.unshift(mapping[cursor]);
+      cursor = mapping[cursor].parent;
+    }
+    const activePath = currentRawPath
+      .map(node => node.message?.id || node.id)
+      .filter(id => visibleNodes.has(id))
+      .map(id => {
+        const node = visibleNodes.get(id);
+        return {
+          id: node.id,
+          turnIndex: node.turnIndex,
+          branchIndex: node.branchIndex,
+          role: node.role,
+          text: node.text,
+        };
+      });
+
+    return {
+      conversationId: data?.conversation_id || data?.id || null,
+      nodes: [...visibleNodes.values()],
+      activePath,
+      rawNodeCount: rawNodes.length,
+    };
+  }
+
+  global.cbvConvertChatGptGraph = convertConversationGraph;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { convertConversationGraph, isVisibleMessage, messageText };
+  }
+})(globalThis);

--- a/chatgpt-page-bridge.js
+++ b/chatgpt-page-bridge.js
@@ -1,0 +1,103 @@
+(function initCbvChatGptPageBridge() {
+  'use strict';
+
+  const SOURCE = 'chat-branch-visualizer';
+  const GRAPH_MESSAGE = 'CHATGPT_GRAPH';
+  const REQUEST_MESSAGE = 'REQUEST_CHATGPT_GRAPH';
+  const MAX_CACHED_GRAPHS = 8;
+  const graphCache = new Map();
+
+  function isConversationResponse(url) {
+    try {
+      const parsed = new URL(String(url || ''), location.href);
+      return /\/backend-api\/conversation\/[^/?#]+\/?$/.test(parsed.pathname);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function rememberGraph(data, sourceUrl) {
+    const graph = globalThis.cbvConvertChatGptGraph?.(data);
+    if (!graph?.conversationId || !graph.nodes?.length) return;
+
+    graphCache.delete(graph.conversationId);
+    graphCache.set(graph.conversationId, { graph, sourceUrl });
+    while (graphCache.size > MAX_CACHED_GRAPHS) {
+      graphCache.delete(graphCache.keys().next().value);
+    }
+    publishGraph(graph, sourceUrl);
+  }
+
+  function publishGraph(graph, sourceUrl) {
+    window.postMessage({
+      source: SOURCE,
+      type: GRAPH_MESSAGE,
+      graph,
+      sourceUrl,
+    }, location.origin);
+  }
+
+  async function inspectResponse(response, sourceUrl) {
+    if (!response?.ok || !isConversationResponse(response.url)) return;
+    try {
+      rememberGraph(await response.clone().json(), sourceUrl);
+    } catch (_) {}
+  }
+
+  function inspectParsedResponse(response, data, sourceUrl) {
+    if (!response?.ok || !isConversationResponse(response.url)) return;
+    try {
+      rememberGraph(typeof data === 'string' ? JSON.parse(data) : data, sourceUrl);
+    } catch (_) {}
+  }
+
+  const nativeFetch = window.fetch;
+  window.fetch = function cbvFetch(...args) {
+    const sourceUrl = location.href;
+    const result = nativeFetch.apply(this, args);
+    result.then(response => inspectResponse(response, sourceUrl)).catch(() => {});
+    return result;
+  };
+
+  const nativeResponseJson = Response.prototype.json;
+  Response.prototype.json = function cbvResponseJson(...args) {
+    const sourceUrl = location.href;
+    const result = nativeResponseJson.apply(this, args);
+    result.then(data => inspectParsedResponse(this, data, sourceUrl)).catch(() => {});
+    return result;
+  };
+
+  const nativeResponseText = Response.prototype.text;
+  Response.prototype.text = function cbvResponseText(...args) {
+    const sourceUrl = location.href;
+    const result = nativeResponseText.apply(this, args);
+    result.then(data => inspectParsedResponse(this, data, sourceUrl)).catch(() => {});
+    return result;
+  };
+
+  const nativeOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function cbvOpen(method, url, ...args) {
+    this.__cbvConversationResponse = isConversationResponse(url);
+    this.__cbvSourceUrl = location.href;
+    return nativeOpen.call(this, method, url, ...args);
+  };
+
+  const nativeSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function cbvSend(...args) {
+    if (this.__cbvConversationResponse) {
+      this.addEventListener('load', () => {
+        if (this.status < 200 || this.status >= 300) return;
+        try {
+          rememberGraph(JSON.parse(this.responseText), this.__cbvSourceUrl);
+        } catch (_) {}
+      }, { once: true });
+    }
+    return nativeSend.apply(this, args);
+  };
+
+  window.addEventListener('message', event => {
+    if (event.source !== window || event.origin !== location.origin) return;
+    if (event.data?.source !== SOURCE || event.data?.type !== REQUEST_MESSAGE) return;
+    for (const entry of graphCache.values()) publishGraph(entry.graph, entry.sourceUrl);
+  });
+})();

--- a/claude-graph.js
+++ b/claude-graph.js
@@ -1,0 +1,96 @@
+(function initCbvClaudeGraph(global) {
+  'use strict';
+
+  const ROOT_MESSAGE_UUID = '00000000-0000-4000-8000-000000000000';
+
+  function messageText(message) {
+    return String(message?.text || '').trim().replace(/\s+/g, ' ');
+  }
+
+  function convertConversationGraph(data) {
+    const messages = Array.isArray(data?.chat_messages) ? data.chat_messages : [];
+    const messageById = new Map(messages.map(message => [message.uuid, message]));
+    const childrenByParent = new Map();
+
+    for (const message of messages) {
+      const parentId = message.parent_message_uuid;
+      const key = messageById.has(parentId) ? parentId : ROOT_MESSAGE_UUID;
+      if (!childrenByParent.has(key)) childrenByParent.set(key, []);
+      childrenByParent.get(key).push(message);
+    }
+
+    for (const children of childrenByParent.values()) {
+      children.sort((left, right) => {
+        const indexDifference = Number(left.index || 0) - Number(right.index || 0);
+        if (indexDifference) return indexDifference;
+        return String(left.created_at || '').localeCompare(String(right.created_at || ''));
+      });
+    }
+
+    const nodes = [];
+    const nodeById = new Map();
+    const visited = new Set();
+
+    function visit(message, depth, parentId = null) {
+      if (!message?.uuid || visited.has(message.uuid)) return;
+      visited.add(message.uuid);
+
+      const siblings = childrenByParent.get(
+        messageById.has(message.parent_message_uuid)
+          ? message.parent_message_uuid
+          : ROOT_MESSAGE_UUID
+      ) || [message];
+      const node = {
+        id: message.uuid,
+        parentId,
+        turnIndex: depth,
+        branchIndex: Math.max(1, siblings.findIndex(sibling => sibling.uuid === message.uuid) + 1),
+        branchTotal: Math.max(1, siblings.length),
+        role: message.sender === 'human' ? 'user' : 'assistant',
+        text: messageText(message).slice(0, 220),
+        children: [],
+      };
+      nodes.push(node);
+      nodeById.set(node.id, node);
+
+      for (const child of childrenByParent.get(message.uuid) || []) {
+        node.children.push(child.uuid);
+        visit(child, depth + 1, node.id);
+      }
+    }
+
+    for (const root of childrenByParent.get(ROOT_MESSAGE_UUID) || []) visit(root, 0);
+    for (const message of messages) {
+      if (!visited.has(message.uuid)) visit(message, 0);
+    }
+
+    const activePath = [];
+    const pathSeen = new Set();
+    let cursor = data?.current_leaf_message_uuid;
+    while (cursor && nodeById.has(cursor) && !pathSeen.has(cursor)) {
+      pathSeen.add(cursor);
+      const node = nodeById.get(cursor);
+      activePath.unshift({
+        id: node.id,
+        turnIndex: node.turnIndex,
+        branchIndex: node.branchIndex,
+        role: node.role,
+        text: node.text,
+      });
+      cursor = node.parentId;
+    }
+
+    return {
+      conversationId: data?.uuid || null,
+      nodes,
+      activePath,
+      rawNodeCount: messages.length,
+    };
+  }
+
+  global.cbvConvertClaudeGraph = convertConversationGraph;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { convertConversationGraph, messageText, ROOT_MESSAGE_UUID };
+  }
+})(globalThis);

--- a/claude-page-bridge.js
+++ b/claude-page-bridge.js
@@ -1,0 +1,94 @@
+(function initCbvClaudePageBridge() {
+  'use strict';
+
+  const SOURCE = 'chat-branch-visualizer';
+  const GRAPH_MESSAGE = 'CLAUDE_GRAPH';
+  const REQUEST_MESSAGE = 'REQUEST_CLAUDE_GRAPH';
+  const CONVERSATION_PATH = /^\/chat\/([^/?#]+)\/?$/;
+  const graphCache = new Map();
+  let inFlight = null;
+
+  function conversationIdFromPage() {
+    return location.pathname.match(CONVERSATION_PATH)?.[1] || null;
+  }
+
+  function isConversationResponse(url, conversationId = conversationIdFromPage()) {
+    try {
+      const parsed = new URL(String(url || ''), location.href);
+      return parsed.origin === location.origin
+        && parsed.pathname.endsWith(`/chat_conversations/${conversationId}`);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function rememberGraph(data, sourceUrl) {
+    const graph = globalThis.cbvConvertClaudeGraph?.(data);
+    if (!graph?.conversationId || !graph.nodes?.length) return null;
+    graphCache.set(graph.conversationId, graph);
+    publishGraph(graph, sourceUrl);
+    return graph;
+  }
+
+  function publishGraph(graph, sourceUrl = location.href) {
+    window.postMessage({
+      source: SOURCE,
+      type: GRAPH_MESSAGE,
+      graph,
+      sourceUrl,
+    }, location.origin);
+  }
+
+  async function fetchCurrentGraph() {
+    const conversationId = conversationIdFromPage();
+    if (!conversationId) return null;
+    const cached = graphCache.get(conversationId);
+    if (cached) publishGraph(cached);
+    if (inFlight) return inFlight;
+
+    inFlight = (async () => {
+      const organizationsResponse = await nativeFetch.call(window, '/api/organizations', {
+        credentials: 'include',
+      });
+      if (!organizationsResponse.ok) return null;
+      const organizations = await organizationsResponse.json();
+      const organizationIds = (Array.isArray(organizations) ? organizations : [organizations])
+        .map(organization => organization?.uuid)
+        .filter(Boolean);
+      for (const organizationId of organizationIds) {
+        const response = await nativeFetch.call(
+          window,
+          `/api/organizations/${organizationId}/chat_conversations/${conversationId}`,
+          { credentials: 'include' }
+        );
+        if (!response.ok) continue;
+        return rememberGraph(await response.json(), location.href);
+      }
+      return null;
+    })().catch(() => null).finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  }
+
+  async function inspectResponse(response, sourceUrl) {
+    if (!response?.ok || !isConversationResponse(response.url)) return;
+    try {
+      rememberGraph(await response.clone().json(), sourceUrl);
+    } catch (_) {}
+  }
+
+  const nativeFetch = window.fetch;
+  window.fetch = function cbvClaudeFetch(...args) {
+    const sourceUrl = location.href;
+    const result = nativeFetch.apply(this, args);
+    result.then(response => inspectResponse(response, sourceUrl)).catch(() => {});
+    return result;
+  };
+
+  window.addEventListener('message', event => {
+    if (event.source !== window || event.origin !== location.origin) return;
+    if (event.data?.source !== SOURCE || event.data?.type !== REQUEST_MESSAGE) return;
+    fetchCurrentGraph();
+  });
+})();

--- a/claude-page-bridge.js
+++ b/claude-page-bridge.js
@@ -58,7 +58,7 @@
       for (const organizationId of organizationIds) {
         const response = await nativeFetch.call(
           window,
-          `/api/organizations/${organizationId}/chat_conversations/${conversationId}`,
+          `/api/organizations/${organizationId}/chat_conversations/${conversationId}?tree=true`,
           { credentials: 'include' }
         );
         if (!response.ok) continue;

--- a/content.js
+++ b/content.js
@@ -13,7 +13,7 @@
   const BUILD_TIMEOUT_MS = 45000;
   const EMPTY_TURN_CONFIRMATIONS = 3;
   const DIAGNOSTIC_SNIPPET_LIMIT = 6;
-  const CHATGPT_GRAPH_WAIT_MS = 1200;
+  const CONVERSATION_GRAPH_WAIT_MS = 3000;
   const BRIDGE_SOURCE = 'chat-branch-visualizer';
   const PLATFORM      = detectPlatform();
   const EXT_VERSION   = chrome.runtime.getManifest().version;
@@ -90,7 +90,7 @@
   let lastDiagnosticSig = '';
   let pageLoadStartedAt = Date.now();
   let emptyTurnPolls = 0;
-  let chatGptGraph = null;
+  let conversationGraph = null;
   let graphWaiters = [];
 
   // ── Platform ────────────────────────────────────────────────────────────────
@@ -107,9 +107,9 @@
       return;
     }
     injectHighlightStyle();
-    if (PLATFORM === 'chatgpt') {
+    if (PLATFORM === 'chatgpt' || PLATFORM === 'claude') {
       window.addEventListener('message', onPageBridgeMessage);
-      requestChatGptGraph();
+      requestConversationGraph();
     }
     loadSelectorConfig().catch(() => {});
     chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
@@ -128,14 +128,15 @@
   function onPageBridgeMessage(event) {
     if (event.source !== window || event.origin !== location.origin) return;
     const payload = event.data;
-    if (payload?.source !== BRIDGE_SOURCE || payload.type !== 'CHATGPT_GRAPH') return;
+    const expectedType = PLATFORM === 'claude' ? 'CLAUDE_GRAPH' : 'CHATGPT_GRAPH';
+    if (payload?.source !== BRIDGE_SOURCE || payload.type !== expectedType) return;
     if (!isGraphForCurrentPage(payload)) return;
     if (!isValidConversationGraph(payload.graph)) return;
 
-    chatGptGraph = payload.graph;
+    conversationGraph = payload.graph;
     const waiters = graphWaiters;
     graphWaiters = [];
-    waiters.forEach(resolve => resolve(chatGptGraph));
+    waiters.forEach(resolve => resolve(conversationGraph));
   }
 
   function isGraphForCurrentPage(payload) {
@@ -155,27 +156,32 @@
     );
   }
 
-  function requestChatGptGraph() {
+  function requestConversationGraph() {
     window.postMessage({
       source: BRIDGE_SOURCE,
-      type: 'REQUEST_CHATGPT_GRAPH',
+      type: PLATFORM === 'claude' ? 'REQUEST_CLAUDE_GRAPH' : 'REQUEST_CHATGPT_GRAPH',
     }, location.origin);
   }
 
-  function waitForChatGptGraph() {
-    if (chatGptGraph) return Promise.resolve(chatGptGraph);
-    requestChatGptGraph();
+  function waitForConversationGraph() {
+    if (conversationGraph) return Promise.resolve(conversationGraph);
+    requestConversationGraph();
     return new Promise(resolve => {
       const timer = setTimeout(() => {
         graphWaiters = graphWaiters.filter(waiter => waiter !== done);
         resolve(null);
-      }, CHATGPT_GRAPH_WAIT_MS);
+      }, CONVERSATION_GRAPH_WAIT_MS);
       const done = graph => {
         clearTimeout(timer);
         resolve(graph);
       };
       graphWaiters.push(done);
     });
+  }
+
+  function refreshConversationGraph() {
+    conversationGraph = null;
+    return waitForConversationGraph();
   }
 
   // ── Message handler ──────────────────────────────────────────────────────────
@@ -394,8 +400,8 @@ function makePathEntry(turn) {
 
     sendToPanel({ type: 'BUILD_START' });
 
-    if (PLATFORM === 'chatgpt') {
-      const graph = await waitForChatGptGraph();
+    if (PLATFORM === 'chatgpt' || PLATFORM === 'claude') {
+      const graph = await waitForConversationGraph();
       if (graph && !cancelled) {
         const treeNodes = new Map(graph.nodes.map(node => [node.id, node]));
         building = false;
@@ -480,27 +486,31 @@ function makePathEntry(turn) {
   // ── NAVIGATE command ─────────────────────────────────────────────────────────
   async function cmdNavigate(path) {
     const activeByDepth = new Map(
-      (chatGptGraph?.activePath || []).map(entry => [entry.turnIndex, entry.id])
+      (conversationGraph?.activePath || []).map(entry => [entry.turnIndex, entry.id])
     );
-    const branchSteps = PLATFORM === 'chatgpt' && chatGptGraph
+    const branchSteps = conversationGraph
       ? path.filter(step => step.branchTotal > 1 && activeByDepth.get(step.turnIndex) !== step.id)
       : path.filter(step => step.branchTotal > 1);
 
+    let switchedBranch = false;
     for (const step of branchSteps) {
       if (step.branchTotal <= 1) continue;
       const turn = await findGraphTurn(step);
       if (!turn) continue;
       if (turn.branchIndex !== step.branchIndex) {
-        await navigateTurnToBranch(turn, step.branchIndex);
+        switchedBranch = await navigateTurnToBranch(turn, step.branchIndex) || switchedBranch;
         await sleep(NAV_WAIT_MS);
       }
     }
+    if (switchedBranch) await refreshConversationGraph();
     const leaf = path[path.length - 1];
     if (leaf) {
       sendToPanel({ type: 'CONVERSATION_LOADING' });
-      const stableTurn = PLATFORM === 'chatgpt' && chatGptGraph
+      const stableTurn = PLATFORM === 'chatgpt' && conversationGraph
         ? await seekChatGptGraphTurn(leaf)
-        : await waitForTurnStable(leaf.turnIndex, leaf.branchIndex);
+        : PLATFORM === 'claude' && conversationGraph
+          ? await seekClaudeGraphTurn(leaf)
+          : await waitForTurnStable(leaf.turnIndex, leaf.branchIndex);
       if (stableTurn?.article) {
         scrollToTurn(stableTurn.article);
         highlightTurn(stableTurn.article);
@@ -516,15 +526,19 @@ function makePathEntry(turn) {
     const turns = readRawTurns();
     const exact = turns.find(candidate => step.id && candidate.domId === step.id);
     if (exact) return exact;
-    if (PLATFORM !== 'chatgpt' || !chatGptGraph) return turns[step.turnIndex] || null;
+    if (!conversationGraph) return turns[step.turnIndex] || null;
 
-    const activeSibling = chatGptGraph.activePath?.find(entry => entry.turnIndex === step.turnIndex);
+    const activeSibling = conversationGraph.activePath?.find(entry => entry.turnIndex === step.turnIndex);
     if (activeSibling?.id) {
       const mountedSibling = turns.find(candidate => candidate.domId === activeSibling.id);
       if (mountedSibling) return mountedSibling;
-      return seekChatGptGraphTurn(activeSibling);
+      return PLATFORM === 'chatgpt'
+        ? seekChatGptGraphTurn(activeSibling)
+        : seekClaudeGraphTurn(activeSibling);
     }
-    return seekChatGptGraphTurn(step);
+    return PLATFORM === 'chatgpt'
+      ? seekChatGptGraphTurn(step)
+      : seekClaudeGraphTurn(step);
   }
 
   async function seekChatGptGraphTurn(step) {
@@ -546,6 +560,43 @@ function makePathEntry(turn) {
   function findMountedChatGptTurn(messageId) {
     if (!messageId) return null;
     return readRawTurns().find(turn => turn.domId === messageId) || null;
+  }
+
+  async function seekClaudeGraphTurn(step) {
+    for (let attempt = 0; attempt < 16; attempt++) {
+      const exact = findMountedClaudeTurn(step);
+      if (exact) return exact;
+
+      const mounted = readRawTurns();
+      const firstIndex = mounted[0]?.turnIndex;
+      const lastIndex = mounted[mounted.length - 1]?.turnIndex;
+      const host = getScrollHost();
+      if (host === window) return null;
+
+      if (Number.isFinite(firstIndex) && Number.isFinite(lastIndex) && lastIndex >= firstIndex) {
+        const mountedSpan = Math.max(1, lastIndex - firstIndex + 1);
+        const pixelPerTurn = Math.max(24, host.clientHeight / mountedSpan);
+        const indexDelta = step.turnIndex < firstIndex
+          ? step.turnIndex - firstIndex
+          : step.turnIndex > lastIndex
+            ? step.turnIndex - lastIndex
+            : 0;
+        host.scrollTop = Math.max(
+          0,
+          Math.min(host.scrollHeight - host.clientHeight, host.scrollTop + indexDelta * pixelPerTurn)
+        );
+      } else {
+        const activeLength = Math.max(1, conversationGraph?.activePath?.length || 1);
+        host.scrollTop = (step.turnIndex / Math.max(1, activeLength - 1))
+          * Math.max(0, host.scrollHeight - host.clientHeight);
+      }
+      await sleep(120);
+    }
+    return findMountedClaudeTurn(step);
+  }
+
+  function findMountedClaudeTurn(step) {
+    return readRawTurns().find(turn => turn.turnIndex === step.turnIndex) || null;
   }
 
   function findChatGptTurnPlaceholder(messageId) {
@@ -665,7 +716,7 @@ function makePathEntry(turn) {
       if (cancelled) return false;
 
       // Retry: re-read the turn and try once more
-      const fresh = readRawTurns()[turn.turnIndex];
+      const fresh = findCurrentTurn(turn);
       if (!fresh) return false;
       if (fresh.branchIndex === target) return true;
 
@@ -685,7 +736,7 @@ function makePathEntry(turn) {
       if (cancelled) return false;
       if (Date.now() > deadline) return false;
 
-      const fresh = readRawTurns()[turn.turnIndex];
+      const fresh = findCurrentTurn(turn);
       if (!fresh) return false;
       if (fresh.branchIndex === target) return true;
       if (target < 1 || target > (fresh.branchTotal || 1)) return false;
@@ -700,7 +751,7 @@ function makePathEntry(turn) {
         // Try once after bringing the turn into view; if still unavailable, fail fast.
         if (fresh.article) scrollToTurn(fresh.article);
         await sleep(Math.min(NAV_WAIT_MS, 220));
-        const retried = readRawTurns()[turn.turnIndex];
+        const retried = findCurrentTurn(turn);
         const retryBtn = wantsNext ? retried?.nextBtn : retried?.prevBtn;
         if (!retryBtn || isDisabledButton(retryBtn)) return false;
         retryBtn.click();
@@ -714,8 +765,16 @@ function makePathEntry(turn) {
     }
 
     // One last check
-    const final = readRawTurns()[turn.turnIndex];
+    const final = findCurrentTurn(turn);
     return final?.branchIndex === target;
+  }
+
+  function findCurrentTurn(turn) {
+    const turns = readRawTurns();
+    return turns.find(candidate => (
+      candidate.turnIndex === turn.turnIndex
+      && (!turn.domId || !candidate.domId || candidate.domId === turn.domId)
+    )) || turns.find(candidate => candidate.turnIndex === turn.turnIndex) || null;
   }
 
   // ── DOM reading ──────────────────────────────────────────────────────────────
@@ -846,15 +905,27 @@ function makePathEntry(turn) {
     const role = userMessage ? 'user' : 'assistant';
     const messageElement = userMessage || assistantMessage || row;
     const nav = role === 'user' ? findClaudeBranchNav(row) : null;
+    const virtualItem = row.closest('[data-index], [data-rs-index], [role="article"][aria-posinset]');
+    const virtualIndex = Number(
+      virtualItem?.getAttribute('data-index')
+      ?? virtualItem?.getAttribute('data-rs-index')
+      ?? Number(virtualItem?.getAttribute('aria-posinset') || 0) - 1
+    );
+    const turnIndex = Number.isFinite(virtualIndex) ? virtualIndex : idx;
+    const graphEntry = conversationGraph?.activePath?.find(entry => entry.turnIndex === turnIndex);
+    const graphNode = graphEntry
+      ? conversationGraph.nodes?.find(node => node.id === graphEntry.id)
+      : null;
     return {
-      turnIndex: idx,
-      domId: row.getAttribute('data-message-id')
+      turnIndex,
+      domId: graphEntry?.id
+        || row.getAttribute('data-message-id')
         || messageElement.getAttribute('data-message-id')
         || null,
       role,
       text: extractText(messageElement),
-      branchIndex: nav?.current ?? 1,
-      branchTotal: nav?.total ?? 1,
+      branchIndex: nav?.current ?? graphNode?.branchIndex ?? 1,
+      branchTotal: nav?.total ?? graphNode?.branchTotal ?? 1,
       prevBtn: nav?.prevBtn ?? null,
       nextBtn: nav?.nextBtn ?? null,
       article: row,
@@ -1324,8 +1395,8 @@ function makePathEntry(turn) {
       if (building) return;
       if (location.href !== lastUrl) {
         lastUrl = location.href;
-        chatGptGraph = null;
-        requestChatGptGraph();
+        conversationGraph = null;
+        requestConversationGraph();
         lastStateSig = '';
         lastVisibleSig = '';
         lastDiagnostics = null;

--- a/content.js
+++ b/content.js
@@ -13,6 +13,8 @@
   const BUILD_TIMEOUT_MS = 45000;
   const EMPTY_TURN_CONFIRMATIONS = 3;
   const DIAGNOSTIC_SNIPPET_LIMIT = 6;
+  const CHATGPT_GRAPH_WAIT_MS = 1200;
+  const BRIDGE_SOURCE = 'chat-branch-visualizer';
   const PLATFORM      = detectPlatform();
   const EXT_VERSION   = chrome.runtime.getManifest().version;
   const OPTIONAL_PROBE_KEYS = {
@@ -88,6 +90,8 @@
   let lastDiagnosticSig = '';
   let pageLoadStartedAt = Date.now();
   let emptyTurnPolls = 0;
+  let chatGptGraph = null;
+  let graphWaiters = [];
 
   // ── Platform ────────────────────────────────────────────────────────────────
   function detectPlatform() {
@@ -103,6 +107,10 @@
       return;
     }
     injectHighlightStyle();
+    if (PLATFORM === 'chatgpt') {
+      window.addEventListener('message', onPageBridgeMessage);
+      requestChatGptGraph();
+    }
     loadSelectorConfig().catch(() => {});
     chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       handleMessage(msg).then(sendResponse);
@@ -115,6 +123,59 @@
     sendToPanel({ type: 'PAGE_READY', platform: PLATFORM, url: location.href });
     syncStateToPanel(true);
     scheduleViewportSync();
+  }
+
+  function onPageBridgeMessage(event) {
+    if (event.source !== window || event.origin !== location.origin) return;
+    const payload = event.data;
+    if (payload?.source !== BRIDGE_SOURCE || payload.type !== 'CHATGPT_GRAPH') return;
+    if (!isGraphForCurrentPage(payload)) return;
+    if (!isValidConversationGraph(payload.graph)) return;
+
+    chatGptGraph = payload.graph;
+    const waiters = graphWaiters;
+    graphWaiters = [];
+    waiters.forEach(resolve => resolve(chatGptGraph));
+  }
+
+  function isGraphForCurrentPage(payload) {
+    try {
+      return new URL(payload.sourceUrl).pathname === location.pathname;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isValidConversationGraph(graph) {
+    return Boolean(
+      graph?.conversationId
+      && Array.isArray(graph.nodes)
+      && graph.nodes.length
+      && Array.isArray(graph.activePath)
+    );
+  }
+
+  function requestChatGptGraph() {
+    window.postMessage({
+      source: BRIDGE_SOURCE,
+      type: 'REQUEST_CHATGPT_GRAPH',
+    }, location.origin);
+  }
+
+  function waitForChatGptGraph() {
+    if (chatGptGraph) return Promise.resolve(chatGptGraph);
+    requestChatGptGraph();
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        graphWaiters = graphWaiters.filter(waiter => waiter !== done);
+        resolve(null);
+      }, CHATGPT_GRAPH_WAIT_MS);
+      const done = graph => {
+        clearTimeout(timer);
+        resolve(graph);
+      };
+      graphWaiters.push(done);
+    });
   }
 
   // ── Message handler ──────────────────────────────────────────────────────────
@@ -330,12 +391,38 @@ function makePathEntry(turn) {
     if (building) return { ok: false, reason: 'already_building' };
     building   = true;
     cancelled  = false;
-    observer?.disconnect();
-
-    const treeNodes = new Map();
-    const buildDeadline = Date.now() + BUILD_TIMEOUT_MS;
 
     sendToPanel({ type: 'BUILD_START' });
+
+    if (PLATFORM === 'chatgpt') {
+      const graph = await waitForChatGptGraph();
+      if (graph && !cancelled) {
+        const treeNodes = new Map(graph.nodes.map(node => [node.id, node]));
+        building = false;
+        sendToPanel({
+          type: 'BUILD_DONE',
+          nodes: graph.nodes,
+          activePath: graph.activePath,
+          source: 'conversation-graph',
+        });
+        saveToStorage(treeNodes, graph.activePath);
+        return panelMessage({ ok: true, source: 'conversation-graph' });
+      }
+      if (cancelled) {
+        building = false;
+        cancelled = false;
+        sendToPanel({ type: 'BUILD_CANCELLED' });
+        return { ok: false, reason: 'cancelled' };
+      }
+      sendToPanel({
+        type: 'BUILD_WARNING',
+        message: 'Conversation data was unavailable — using page traversal fallback',
+      });
+    }
+
+    observer?.disconnect();
+    const treeNodes = new Map();
+    const buildDeadline = Date.now() + BUILD_TIMEOUT_MS;
 
     try {
       await dfsCollect(null, 0, treeNodes, buildDeadline);
@@ -392,10 +479,16 @@ function makePathEntry(turn) {
 
   // ── NAVIGATE command ─────────────────────────────────────────────────────────
   async function cmdNavigate(path) {
-    for (const step of path) {
+    const activeByDepth = new Map(
+      (chatGptGraph?.activePath || []).map(entry => [entry.turnIndex, entry.id])
+    );
+    const branchSteps = PLATFORM === 'chatgpt' && chatGptGraph
+      ? path.filter(step => step.branchTotal > 1 && activeByDepth.get(step.turnIndex) !== step.id)
+      : path.filter(step => step.branchTotal > 1);
+
+    for (const step of branchSteps) {
       if (step.branchTotal <= 1) continue;
-      const turns = readRawTurns();
-      const turn  = turns[step.turnIndex];
+      const turn = await findGraphTurn(step);
       if (!turn) continue;
       if (turn.branchIndex !== step.branchIndex) {
         await navigateTurnToBranch(turn, step.branchIndex);
@@ -405,7 +498,9 @@ function makePathEntry(turn) {
     const leaf = path[path.length - 1];
     if (leaf) {
       sendToPanel({ type: 'CONVERSATION_LOADING' });
-      const stableTurn = await waitForTurnStable(leaf.turnIndex, leaf.branchIndex);
+      const stableTurn = PLATFORM === 'chatgpt' && chatGptGraph
+        ? await seekChatGptGraphTurn(leaf)
+        : await waitForTurnStable(leaf.turnIndex, leaf.branchIndex);
       if (stableTurn?.article) {
         scrollToTurn(stableTurn.article);
         highlightTurn(stableTurn.article);
@@ -415,6 +510,48 @@ function makePathEntry(turn) {
     sendToPanel({ type: 'NAV_DONE', activePath });
     scheduleViewportSync();
     return panelMessage({ ok: true, activePath });
+  }
+
+  async function findGraphTurn(step) {
+    const turns = readRawTurns();
+    const exact = turns.find(candidate => step.id && candidate.domId === step.id);
+    if (exact) return exact;
+    if (PLATFORM !== 'chatgpt' || !chatGptGraph) return turns[step.turnIndex] || null;
+
+    const activeSibling = chatGptGraph.activePath?.find(entry => entry.turnIndex === step.turnIndex);
+    if (activeSibling?.id) {
+      const mountedSibling = turns.find(candidate => candidate.domId === activeSibling.id);
+      if (mountedSibling) return mountedSibling;
+      return seekChatGptGraphTurn(activeSibling);
+    }
+    return seekChatGptGraphTurn(step);
+  }
+
+  async function seekChatGptGraphTurn(step) {
+    const exact = findMountedChatGptTurn(step.id);
+    if (exact) return exact;
+
+    const placeholder = findChatGptTurnPlaceholder(step.id);
+    if (!placeholder) return null;
+    placeholder.scrollIntoView({ block: 'center', behavior: 'instant' });
+
+    for (let attempt = 0; attempt < 12; attempt++) {
+      await sleep(100);
+      const mounted = findMountedChatGptTurn(step.id);
+      if (mounted) return mounted;
+    }
+    return null;
+  }
+
+  function findMountedChatGptTurn(messageId) {
+    if (!messageId) return null;
+    return readRawTurns().find(turn => turn.domId === messageId) || null;
+  }
+
+  function findChatGptTurnPlaceholder(messageId) {
+    if (!messageId) return null;
+    return [...document.querySelectorAll('[data-turn-id-container]')]
+      .find(element => element.getAttribute('data-turn-id-container') === messageId) || null;
   }
 
   // ── DFS tree builder ─────────────────────────────────────────────────────────
@@ -649,6 +786,9 @@ function makePathEntry(turn) {
   // users to switch between edited messages. The assistant response following
   // each branch is considered a child of that branch.
   function readClaudeTurns() {
+    const messageRows = getClaudeMessageRows();
+    if (messageRows.length) return messageRows.map(mapClaudeMessageRow);
+
     const userEls = getClaudeUserTurns();
     if (!userEls.length) {
       const assistantOnly = getClaudeAssistantFallbackTurns();
@@ -690,6 +830,35 @@ function makePathEntry(turn) {
     });
 
     return turns;
+  }
+
+  function getClaudeMessageRows() {
+    const rows = safeQueryAll('[class*="group/message-row"]');
+    return rows
+      .filter(row => !rows.some(other => other !== row && other.contains(row)))
+      .filter(row => row.querySelector('[data-testid="user-message"], .standard-markdown'))
+      .sort((a, b) => rectTop(a) - rectTop(b));
+  }
+
+  function mapClaudeMessageRow(row, idx) {
+    const userMessage = row.querySelector('[data-testid="user-message"]');
+    const assistantMessage = row.querySelector('.standard-markdown');
+    const role = userMessage ? 'user' : 'assistant';
+    const messageElement = userMessage || assistantMessage || row;
+    const nav = role === 'user' ? findClaudeBranchNav(row) : null;
+    return {
+      turnIndex: idx,
+      domId: row.getAttribute('data-message-id')
+        || messageElement.getAttribute('data-message-id')
+        || null,
+      role,
+      text: extractText(messageElement),
+      branchIndex: nav?.current ?? 1,
+      branchTotal: nav?.total ?? 1,
+      prevBtn: nav?.prevBtn ?? null,
+      nextBtn: nav?.nextBtn ?? null,
+      article: row,
+    };
   }
 
   function getClaudeUserTurns() {
@@ -1155,6 +1324,8 @@ function makePathEntry(turn) {
       if (building) return;
       if (location.href !== lastUrl) {
         lastUrl = location.href;
+        chatGptGraph = null;
+        requestChatGptGraph();
         lastStateSig = '';
         lastVisibleSig = '';
         lastDiagnostics = null;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat Branch Visualizer",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Visualize conversation branches in ChatGPT/Claude as a native sidebar.",
   "permissions": ["storage", "sidePanel", "tabs"],
   "host_permissions": [
@@ -26,6 +26,15 @@
     }
   },
   "content_scripts": [
+    {
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://chat.openai.com/*"
+      ],
+      "js": ["chatgpt-graph.js", "chatgpt-page-bridge.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
     {
       "matches": [
         "https://chatgpt.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat Branch Visualizer",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Visualize conversation branches in ChatGPT/Claude as a native sidebar.",
   "permissions": ["storage", "sidePanel", "tabs"],
   "host_permissions": [
@@ -32,6 +32,14 @@
         "https://chat.openai.com/*"
       ],
       "js": ["chatgpt-graph.js", "chatgpt-page-bridge.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": [
+        "https://claude.ai/*"
+      ],
+      "js": ["claude-graph.js", "claude-page-bridge.js"],
       "run_at": "document_start",
       "world": "MAIN"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat Branch Visualizer",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Visualize conversation branches in ChatGPT/Claude as a native sidebar.",
   "permissions": ["storage", "sidePanel", "tabs"],
   "host_permissions": [

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -21,6 +21,8 @@ const INCLUDE = [
   'content.js',
   'chatgpt-graph.js',
   'chatgpt-page-bridge.js',
+  'claude-graph.js',
+  'claude-page-bridge.js',
   'platform-config.js',
   'conversation-routes.js',
   'nav-geometry.js',

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -19,6 +19,8 @@ const INCLUDE = [
   'manifest.json',
   'background.js',
   'content.js',
+  'chatgpt-graph.js',
+  'chatgpt-page-bridge.js',
   'platform-config.js',
   'conversation-routes.js',
   'nav-geometry.js',

--- a/selectors.json
+++ b/selectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lastVerified": "2026-08-11",
   "platforms": {
     "chatgpt": {

--- a/selectors.json
+++ b/selectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lastVerified": "2026-08-11",
   "platforms": {
     "chatgpt": {

--- a/selectors.json
+++ b/selectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lastVerified": "2026-08-11",
   "platforms": {
     "chatgpt": {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -283,17 +283,16 @@ function onContentMessage(msg) {
       const wasPartial = treeCompleteness === 'partial';
       msg.turns = sanitizeTurns(msg.turns);
       if (treeCompleteness !== 'full') {
-        if (msg.turns.length) mergeTurnsIntoTree(msg.turns);
-        else replaceTreeWithTurns(msg.turns);
+        replaceTreeWithTurns(msg.turns);
         setTreeCompleteness(msg.turns.length ? 'partial' : (treeLoadingMode === 'conversation' ? 'loading' : 'empty'));
+        setActivePathState(sanitizePathTurns(msg.turns.map(t => ({
+          id: t.id || `t${t.turnIndex}_b${t.branchIndex}`,
+          turnIndex: t.turnIndex,
+          branchIndex: t.branchIndex,
+          role: t.role,
+          text: t.text,
+        }))));
       }
-      setActivePathState(sanitizePathTurns(msg.turns.map(t => ({
-        id: t.id || `t${t.turnIndex}_b${t.branchIndex}`,
-        turnIndex: t.turnIndex,
-        branchIndex: t.branchIndex,
-        role: t.role,
-        text: t.text,
-      }))));
       setVisiblePathState([]);
       if (treeCompleteness === 'partial' && (wasEmpty || !wasPartial)) setExpandedByDefaultForPartial();
       renderTree();
@@ -305,7 +304,9 @@ function onContentMessage(msg) {
       treeSource = 'live';
       setTreeCompleteness('building');
       setProgress(0); showProgress();
-      showTreeLoading('Building full tree…', `${assistantDisplayName()} may switch branches while history is collected`, 'build');
+      showTreeLoading('Building full tree…', currentPlatform === 'chatgpt'
+        ? 'Reading the conversation graph'
+        : `${assistantDisplayName()} may switch branches while history is collected`, 'build');
       setStatus('Building tree…', 'working');
       setBuildBusy();
       break;
@@ -397,18 +398,11 @@ function onContentMessage(msg) {
       msg.turns = sanitizeTurns(msg.turns);
       msg.activePath = sanitizePathTurns(msg.activePath);
       const isFull = treeCompleteness === 'full';
-      const isSnapshot = treeSource === 'snapshot';
-      if (!isFull || !isSnapshot) {
-        if (msg.turns.length) {
-          mergeTurnsIntoTree(msg.turns);
-        } else if (!isFull) {
-          replaceTreeWithTurns(msg.turns);
-        }
-        if (!isFull) {
-          setTreeCompleteness(msg.turns.length ? 'partial' : (treeLoadingMode === 'conversation' ? 'loading' : 'empty'));
-        }
+      if (!isFull) {
+        replaceTreeWithTurns(msg.turns);
+        setTreeCompleteness(msg.turns.length ? 'partial' : (treeLoadingMode === 'conversation' ? 'loading' : 'empty'));
+        setActivePathState(msg.activePath);
       }
-      setActivePathState(msg.activePath);
       if (msg.turns.length > 0 || msg.activePath.length > 0) hideTreeLoading(false);
       if (treeCompleteness === 'partial' && (wasEmpty || !wasPartial)) setExpandedByDefaultForPartial();
       renderTree();
@@ -449,7 +443,12 @@ function navigateTo(nodeId) {
   const path = [];
   let cur = node;
   while (cur) {
-    path.unshift({ turnIndex: cur.turnIndex, branchIndex: cur.branchIndex, branchTotal: cur.branchTotal });
+    path.unshift({
+      id: cur.id,
+      turnIndex: cur.turnIndex,
+      branchIndex: cur.branchIndex,
+      branchTotal: cur.branchTotal,
+    });
     cur = cur.parentId ? treeNodes.get(cur.parentId) : null;
   }
   sendToContent({ type: 'NAVIGATE', path });
@@ -530,47 +529,6 @@ function describeActivePathStatus(path) {
   const leaf = (path || []).at(-1);
   if (!leaf) return 'Navigation complete';
   return `Viewing turn ${leaf.turnIndex + 1}, branch ${leaf.branchIndex}`;
-}
-
-function mergeTurnsIntoTree(turns) {
-  turns = sanitizeTurns(turns);
-  if (!turns?.length) return;
-  let parentId = null;
-  for (const turn of turns) {
-    const id = turn.id || `t${turn.turnIndex}_b${turn.branchIndex}`;
-    const existing = treeNodes.get(id);
-    const node = treeNodes.get(id) || {
-      id,
-      parentId,
-      turnIndex: turn.turnIndex,
-      branchIndex: turn.branchIndex,
-      branchTotal: turn.branchTotal || 1,
-      role: turn.role,
-      text: turn.text || '',
-      children: [],
-    };
-
-    const oldParentId = existing?.parentId ?? null;
-    if (oldParentId && oldParentId !== parentId && treeNodes.has(oldParentId)) {
-      const oldParent = treeNodes.get(oldParentId);
-      oldParent.children = (oldParent.children || []).filter(childId => childId !== id);
-    }
-
-    node.parentId = parentId;
-    node.turnIndex = turn.turnIndex;
-    node.branchIndex = turn.branchIndex;
-    node.branchTotal = Math.max(node.branchTotal || 1, turn.branchTotal || 1);
-    node.role = turn.role;
-    node.text = turn.text || node.text;
-    if (!Array.isArray(node.children)) node.children = [];
-    treeNodes.set(id, node);
-
-    if (parentId && treeNodes.has(parentId)) {
-      const parent = treeNodes.get(parentId);
-      if (!parent.children.includes(id)) parent.children.push(id);
-    }
-    parentId = id;
-  }
 }
 
 function replaceTreeWithTurns(turns) {

--- a/test/chatgpt-graph.test.js
+++ b/test/chatgpt-graph.test.js
@@ -1,0 +1,117 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  convertConversationGraph,
+  isVisibleMessage,
+  messageText,
+} = require('../chatgpt-graph');
+
+function message(id, role, text, overrides = {}) {
+  return {
+    id,
+    author: { role },
+    content: { content_type: 'text', parts: [text] },
+    channel: role === 'assistant' ? 'final' : null,
+    end_turn: role === 'assistant',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function node(id, parent, children, nodeMessage = null) {
+  return { id, parent, children, message: nodeMessage };
+}
+
+test('extracts text from string and structured content parts', () => {
+  assert.equal(messageText({
+    content: {
+      parts: ['first', { text: 'second' }, { image_url: 'ignored' }],
+    },
+  }), 'first second');
+});
+
+test('only accepts visible user messages and final assistant replies', () => {
+  assert.equal(isVisibleMessage(message('u1', 'user', 'hello')), true);
+  assert.equal(isVisibleMessage(message('a1', 'assistant', 'answer')), true);
+  assert.equal(isVisibleMessage(message('a1b', 'assistant', 'legacy answer', {
+    channel: null,
+    status: 'finished_successfully',
+  })), true);
+  assert.equal(isVisibleMessage(message('a1c', 'assistant', 'voice answer', {
+    channel: null,
+    content: { content_type: 'multimodal_text', parts: ['voice answer'] },
+    status: 'finished_successfully',
+  })), true);
+  assert.equal(isVisibleMessage(message('a2', 'assistant', 'thinking', {
+    channel: 'analysis',
+    end_turn: false,
+  })), false);
+  assert.equal(isVisibleMessage(message('a3', 'assistant', 'commentary', {
+    channel: 'commentary',
+    end_turn: false,
+  })), false);
+  assert.equal(isVisibleMessage(message('a4', 'assistant', 'streaming', {
+    status: 'in_progress',
+  })), false);
+  assert.equal(isVisibleMessage(message('t1', 'tool', 'result')), false);
+});
+
+test('compresses internal nodes while preserving branches and active path', () => {
+  const mapping = {
+    root: node('root', null, ['u1']),
+    u1: node('u1', 'root', ['thought'], message('user-message-1', 'user', 'Question')),
+    thought: node('thought', 'u1', ['a1', 'tool'], message('thought-message', 'assistant', 'Reasoning', {
+      content: { content_type: 'thoughts', parts: ['Reasoning'] },
+      channel: 'analysis',
+      end_turn: false,
+    })),
+    tool: node('tool', 'thought', ['a2'], message('tool-message', 'tool', 'Search result')),
+    a1: node('a1', 'thought', [], message('assistant-message-1', 'assistant', 'First answer')),
+    a2: node('a2', 'tool', [], message('assistant-message-2', 'assistant', 'Second answer')),
+  };
+
+  const graph = convertConversationGraph({
+    conversation_id: 'conversation-1',
+    current_node: 'a2',
+    mapping,
+  });
+
+  assert.equal(graph.conversationId, 'conversation-1');
+  assert.equal(graph.rawNodeCount, 6);
+  assert.deepEqual(graph.nodes.map(node => node.id), [
+    'user-message-1',
+    'assistant-message-1',
+    'assistant-message-2',
+  ]);
+
+  const user = graph.nodes[0];
+  const firstAnswer = graph.nodes[1];
+  const secondAnswer = graph.nodes[2];
+  assert.deepEqual(user.children, ['assistant-message-1', 'assistant-message-2']);
+  assert.deepEqual(
+    [firstAnswer.branchIndex, firstAnswer.branchTotal, secondAnswer.branchIndex, secondAnswer.branchTotal],
+    [1, 2, 2, 2]
+  );
+  assert.equal(firstAnswer.parentId, user.id);
+  assert.equal(secondAnswer.parentId, user.id);
+  assert.deepEqual(graph.activePath.map(entry => entry.id), [
+    'user-message-1',
+    'assistant-message-2',
+  ]);
+});
+
+test('uses visible depth as turnIndex across compressed internal nodes', () => {
+  const mapping = {
+    root: node('root', null, ['u1']),
+    u1: node('u1', 'root', ['hidden'], message('u1-message', 'user', 'One')),
+    hidden: node('hidden', 'u1', ['a1'], message('hidden-message', 'assistant', 'Hidden', {
+      metadata: { is_visually_hidden_from_conversation: true },
+    })),
+    a1: node('a1', 'hidden', ['u2'], message('a1-message', 'assistant', 'Two')),
+    u2: node('u2', 'a1', [], message('u2-message', 'user', 'Three')),
+  };
+
+  const graph = convertConversationGraph({ current_node: 'u2', mapping });
+  assert.deepEqual(graph.nodes.map(entry => entry.turnIndex), [0, 1, 2]);
+});

--- a/test/claude-graph.test.js
+++ b/test/claude-graph.test.js
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  convertConversationGraph,
+  messageText,
+  ROOT_MESSAGE_UUID,
+} = require('../claude-graph');
+
+function message(uuid, sender, index, parent, text = uuid) {
+  return {
+    uuid,
+    sender,
+    index,
+    parent_message_uuid: parent,
+    text,
+  };
+}
+
+test('normalizes Claude message text', () => {
+  assert.equal(messageText({ text: ' first\n  second ' }), 'first second');
+});
+
+test('converts parent UUIDs into a branched tree and active path', () => {
+  const graph = convertConversationGraph({
+    uuid: 'conversation-1',
+    current_leaf_message_uuid: 'a2',
+    chat_messages: [
+      message('u1', 'human', 0, ROOT_MESSAGE_UUID, 'Question'),
+      message('a1', 'assistant', 1, 'u1', 'First answer'),
+      message('a2', 'assistant', 1, 'u1', 'Second answer'),
+      message('u2', 'human', 2, 'a2', 'Follow-up'),
+    ],
+  });
+
+  assert.equal(graph.conversationId, 'conversation-1');
+  assert.equal(graph.rawNodeCount, 4);
+  assert.deepEqual(graph.nodes.map(node => node.id), ['u1', 'a1', 'a2', 'u2']);
+  assert.deepEqual(graph.nodes[0].children, ['a1', 'a2']);
+  assert.deepEqual(
+    graph.nodes.slice(1, 3).map(node => [node.branchIndex, node.branchTotal]),
+    [[1, 2], [2, 2]]
+  );
+  assert.deepEqual(graph.activePath.map(node => node.id), ['u1', 'a2']);
+});
+
+test('sorts sibling branches deterministically and preserves full depth', () => {
+  const graph = convertConversationGraph({
+    uuid: 'conversation-2',
+    current_leaf_message_uuid: 'u2',
+    chat_messages: [
+      message('a2', 'assistant', 3, 'u1', 'Later'),
+      message('u1', 'human', 0, ROOT_MESSAGE_UUID, 'Start'),
+      message('u2', 'human', 4, 'a1', 'Continue'),
+      message('a1', 'assistant', 1, 'u1', 'Earlier'),
+    ],
+  });
+
+  assert.deepEqual(graph.nodes.map(node => node.id), ['u1', 'a1', 'u2', 'a2']);
+  assert.deepEqual(graph.nodes.map(node => node.turnIndex), [0, 1, 2, 1]);
+  assert.deepEqual(graph.activePath.map(node => node.id), ['u1', 'a1', 'u2']);
+});

--- a/test/claude-page-bridge.test.js
+++ b/test/claude-page-bridge.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('requests Claude conversation data in full-tree mode', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'claude-page-bridge.js'),
+    'utf8'
+  );
+
+  assert.match(
+    source,
+    /chat_conversations\/\$\{conversationId\}\?tree=true/
+  );
+});

--- a/viewer.js
+++ b/viewer.js
@@ -145,17 +145,16 @@ function onContentMessage(msg) {
       const wasPartial = treeCompleteness === 'partial';
       msg.turns = sanitizeTurns(msg.turns);
       if (treeCompleteness !== 'full') {
-        if (msg.turns.length) mergeTurnsIntoTree(msg.turns);
-        else replaceTreeWithTurns(msg.turns);
+        replaceTreeWithTurns(msg.turns);
         setTreeCompleteness(msg.turns.length ? 'partial' : (treeLoadingMode === 'conversation' ? 'loading' : 'empty'));
+        setActivePathState(sanitizePathTurns(msg.turns.map(t => ({
+          id: t.id || `t${t.turnIndex}_b${t.branchIndex}`,
+          turnIndex: t.turnIndex,
+          branchIndex: t.branchIndex,
+          role: t.role,
+          text: t.text,
+        }))));
       }
-      setActivePathState(sanitizePathTurns(msg.turns.map(t => ({
-        id: t.id || `t${t.turnIndex}_b${t.branchIndex}`,
-        turnIndex: t.turnIndex,
-        branchIndex: t.branchIndex,
-        role: t.role,
-        text: t.text,
-      }))));
       setVisiblePathState([]);
       if (treeCompleteness === 'partial' && (wasEmpty || !wasPartial)) setExpandedByDefaultForPartial();
       renderTree();
@@ -245,11 +244,10 @@ function onContentMessage(msg) {
       msg.turns = sanitizeTurns(msg.turns);
       msg.activePath = sanitizePathTurns(msg.activePath);
       if (treeCompleteness !== 'full') {
-        if (msg.turns.length) mergeTurnsIntoTree(msg.turns);
-        else replaceTreeWithTurns(msg.turns);
+        replaceTreeWithTurns(msg.turns);
         setTreeCompleteness(msg.turns.length ? 'partial' : (treeLoadingMode === 'conversation' ? 'loading' : 'empty'));
+        setActivePathState(msg.activePath);
       }
-      setActivePathState(msg.activePath);
       if (msg.turns.length > 0 || msg.activePath.length > 0) hideTreeLoading(false);
       if (treeCompleteness === 'partial' && (wasEmpty || !wasPartial)) setExpandedByDefaultForPartial();
       renderTree();
@@ -366,47 +364,6 @@ function describeActivePathStatus(path) {
   const leaf = (path || []).at(-1);
   if (!leaf) return 'Navigation complete';
   return `Viewing turn ${leaf.turnIndex + 1}, branch ${leaf.branchIndex}`;
-}
-
-function mergeTurnsIntoTree(turns) {
-  turns = sanitizeTurns(turns);
-  if (!turns?.length) return;
-  let parentId = null;
-  for (const turn of turns) {
-    const id = turn.id || `t${turn.turnIndex}_b${turn.branchIndex}`;
-    const existing = treeNodes.get(id);
-    const node = treeNodes.get(id) || {
-      id,
-      parentId,
-      turnIndex: turn.turnIndex,
-      branchIndex: turn.branchIndex,
-      branchTotal: turn.branchTotal || 1,
-      role: turn.role,
-      text: turn.text || '',
-      children: [],
-    };
-
-    const oldParentId = existing?.parentId ?? null;
-    if (oldParentId && oldParentId !== parentId && treeNodes.has(oldParentId)) {
-      const oldParent = treeNodes.get(oldParentId);
-      oldParent.children = (oldParent.children || []).filter(childId => childId !== id);
-    }
-
-    node.parentId = parentId;
-    node.turnIndex = turn.turnIndex;
-    node.branchIndex = turn.branchIndex;
-    node.branchTotal = Math.max(node.branchTotal || 1, turn.branchTotal || 1);
-    node.role = turn.role;
-    node.text = turn.text || node.text;
-    if (!Array.isArray(node.children)) node.children = [];
-    treeNodes.set(id, node);
-
-    if (parentId && treeNodes.has(parentId)) {
-      const parent = treeNodes.get(parentId);
-      if (!parent.children.includes(id)) parent.children.push(id);
-    }
-    parentId = id;
-  }
 }
 
 function replaceTreeWithTurns(turns) {


### PR DESCRIPTION
## Summary
- capture ChatGPT's own `/backend-api/conversation/:id` response in the MAIN world
- convert the complete ChatGPT mapping into visible user and final-assistant nodes without scrolling virtualized history
- fetch Claude's authenticated conversation API in the MAIN world and convert `uuid` / `parent_message_uuid` relationships into a complete tree
- navigate virtualized ChatGPT nodes through native placeholders and Claude nodes through global virtual-list indices
- refresh Claude graph state after branch switches
- replace Partial trees with the current DOM window and freeze Full trees so scrolling cannot create duplicate branches
- preserve standard, branch, Project, and Custom GPT conversation routes
- release as v0.3.11

## Validation
- `node --test` (26 passed)
- syntax checks for content script and both ChatGPT/Claude graph bridges
- `npm run pack`; latest artifact: `dist/chat-branch-visualizer-0.3.11.zip` (84.8 KB)
- ChatGPT E2E: complete graph build, off-screen node navigation in about 134 ms, and Full tree unchanged after scrolling (`471 nodes / 84 branch nodes`)
- Claude E2E on `0bb0268c-01bd-440c-a40d-8cf4b43835d4`: API graph build produced `1583 unique nodes / 113 leaves`, with one root and no duplicate UUIDs
- Claude API regression proof: the plain endpoint returned only the `1310`-message active path with `0` branch parents; `?tree=true` returned `1583` unique messages with `93` branch parents (up to 5 children) under the same current leaf
- Claude scroll E2E: top/middle/bottom scrolling kept the Full tree unchanged at `1583 nodes / 113 branches`
- Claude active-path navigation: off-screen target mounted, entered the viewport, and highlighted in about 619 ms
- Claude branch navigation: switched the real branch counter to `1 / 2`, entered the viewport, and highlighted in about 1.1 s

Closes #56
Closes #57
